### PR TITLE
Add io-console as a dependency in the Gemspec

### DIFF
--- a/thor.gemspec
+++ b/thor.gemspec
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require "thor/version"
 
 Gem::Specification.new do |spec|
+  spec.add_dependency "io-console", "~> 0.4"
   spec.add_development_dependency "bundler", "~> 1.0"
   spec.authors = ["Yehuda Katz", "José Valim"]
   spec.description = "Thor is a toolkit for building powerful command-line interfaces."


### PR DESCRIPTION
:rainbow: 

This was added in eb3ceb24dc7bdb08498c755b3a37001c5d74b2e9
but used a direct require without declaring the dependency.
The gemspec should declare this so that users do not have
to install io-console separately to use Thor's basic shell
if they're on Ruby >= 1.9.2
